### PR TITLE
🔧 Update homepage URL in composer.json to use lowercase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "barcode",
         "decoder"
     ],
-    "homepage": "https://github.com/Brixion/Bardecoder",
+    "homepage": "https://github.com/brixion/bardecoder",
     "type": "library",
     "require": {
         "php": "^8.0"


### PR DESCRIPTION
## 📝 Beschrijving

This PR corrects the GitHub URL in the composer.json homepage field from uppercase to lowercase letters. This follows GitHub's convention for repository URLs using kebab-case.

