### PR TITLE
➕ Add friendsofphp/php-cs-fixer and run fix with @Symfony ruleset

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,14 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var', 'vendor');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": ">=7.4"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.88",
         "phpunit/phpunit": "^9.5"
     },
     "license": "MIT",

--- a/src/HIBCSecondaryDataDecoder.php
+++ b/src/HIBCSecondaryDataDecoder.php
@@ -2,67 +2,48 @@
 
 namespace Brixion\Bardecoder;
 
-use Exception;
-use PDO;
-
 /**
- * Class UdiDecoder
- * @package Brixion\Bardecoder
- * 
- * probably wrong also but i tried
- * +primary_data/$lot_number/expiry_date/manufacture_date/serial_number
- * +primary_data/$$5expiry_date/expiry_date/manufacture_date/serial_number
- * +primary_data/$[a-zA-Z0-9]no_date_fields/serial_number
- * +primary_data/$$[0-9]date_field_specified_format/lot_number_no_serial
- * +primary_data/$$+[0-9]date_field_specified_format/serial_number_no_lot
- * +primary_data/$[a-zA-Z0-9]no_date_fields/serial_number
- * +primary_data/$[a-zA-Z0-9]no_date_fields/serial_number
- * +primary_data/$[a-zA-Z0-9]no_date_fields/serial_number
- * 
- * +primary_data/[0-9]julian_date/expiry_date/manufacture_date/serial_number <- legacy, for backwards compatibility
- * +primary_data/$+[a-zA-Z0-9]serial_number_only <- legacy, for backwards compatibility
- * 
- * 
+ * Class UdiDecoder.
+ *
  * probably wrong
  * +primary_data/[0-9]julian_date
  * +primary_data/$[a-zA-Z0-9](lot||serial)
  * +primary_data/$+[a-zA-Z0-9]serial <- backwads compatible
  * +primary_data/$$[0-9]expiry_date/lot/
  */
-
 class HIBCSecondaryDataDecoder
 {
-
-    function __construct(UdiDecoder &$decoder)
+    public function __construct(UdiDecoder &$decoder)
     {
         $this->decoder = $decoder;
 
-        if (empty($this->decoder->secondary_parts))
-            throw new Exception("No secondary data found");
+        if (empty($this->decoder->secondary_parts)) {
+            throw new \Exception('No secondary data found');
+        }
 
         foreach ($this->decoder->secondary_parts as $part) {
             // part is too short or empty to be valid
-            if (!is_string($part) || strlen($part) < 2) {
+            if (!\is_string($part) || \strlen($part) < 2) {
                 continue;
             }
             // Remove illegal + character
-            if ($part[0] == "+") {
+            if ('+' == $part[0]) {
                 $part = substr($part, 1);
             }
 
             // $$[0-9] -> date field
             if (preg_match('/^\$\$[0-9]/', $part)) {
                 $this->handleDateField($part);
-            } elseif (substr($part, 0, 2) == "$+"){
+            } elseif ('$+' == substr($part, 0, 2)) {
                 // This is a serial but we save it as a lot
                 $this->decoder->lot = substr($part, 2);
-            } elseif ($part[0] == "$") {
+            } elseif ('$' == $part[0]) {
                 $this->decoder->lot = substr($part, 1);
-            } elseif (substr($part, 0, 3) == "16D") {
+            } elseif ('16D' == substr($part, 0, 3)) {
                 $this->decoder->date_of_manufacture = $this->getDateFromYYYYMMDD(substr($part, 3));
-            } elseif (substr($part, 0, 3) == "14D") {
+            } elseif ('14D' == substr($part, 0, 3)) {
                 $this->decoder->expiry_date = $this->getDateFromYYYYMMDD(substr($part, 3));
-            } elseif (substr($part, 0, 1) == "S") {
+            } elseif ('S' == substr($part, 0, 1)) {
                 $this->decoder->serial_number = substr($part, 1);
             }
         }
@@ -70,7 +51,7 @@ class HIBCSecondaryDataDecoder
 
     public function getDateFromYYYYMMDD($date)
     {
-        return substr($date, 0, 4) . '-' . substr($date, 4, 2) . '-' . substr($date, 6, 2);
+        return substr($date, 0, 4).'-'.substr($date, 4, 2).'-'.substr($date, 6, 2);
     }
 
     public function handleDateField($part)
@@ -81,22 +62,23 @@ class HIBCSecondaryDataDecoder
                 // MMYY format, followed by lot
                 $mm = substr($part, 3, 2);
                 $yy = substr($part, 5, 2);
-                $max_day = date('t', strtotime($mm . '-' . $yy));
+                $max_day = date('t', strtotime($mm.'-'.$yy));
                 $this->decoder->expiry_date = "20$yy-$mm-$max_day";
                 $this->decoder->lot = substr($part, 8);
+                // no break
             case '1':
                 // first day of month, date in MMYY format
                 $date = substr($part, 2, 4);
                 $month = substr($date, 0, 2);
-                $year = "20" . substr($date, 2, 2);
-                $last_day = date('t', strtotime($year . '-' . $month . '-01'));
+                $year = '20'.substr($date, 2, 2);
+                $last_day = date('t', strtotime($year.'-'.$month.'-01'));
                 $this->decoder->expiry_date = "$year-$month-$last_day";
                 $this->decoder->lot = substr($part, 6);
                 break;
             case '2':
                 // MMDDYY format
                 $date = substr($part, 3, 6);
-                $year = "20" . substr($date, 4, 2);
+                $year = '20'.substr($date, 4, 2);
                 $month = substr($date, 0, 2);
                 $day = substr($date, 2, 2);
 
@@ -105,7 +87,7 @@ class HIBCSecondaryDataDecoder
                 break;
             case '3':
                 // YYMMDD format
-                $year = "20" . substr($part, 3, 2);
+                $year = '20'.substr($part, 3, 2);
                 $month = substr($part, 5, 2);
                 $day = substr($part, 7, 2);
 
@@ -114,7 +96,7 @@ class HIBCSecondaryDataDecoder
                 break;
             case '4':
                 // YYMMDDHH format
-                $year = "20" . substr($part, 3, 2);
+                $year = '20'.substr($part, 3, 2);
                 $month = substr($part, 7, 2);
                 $day = substr($part, 5, 2);
                 $hour = substr($part, 9, 2);
@@ -130,7 +112,7 @@ class HIBCSecondaryDataDecoder
                 break;
             case '6':
                 // YYJJJHH julian date format
-                $this->decoder->expiry_date = jdtojulian(substr($part, 3, 5)) . " " . substr($part, 9, 2);
+                $this->decoder->expiry_date = jdtojulian(substr($part, 3, 5)).' '.substr($part, 9, 2);
                 $this->decoder->lot = substr($part, 10);
                 break;
             case '7':
@@ -143,52 +125,55 @@ class HIBCSecondaryDataDecoder
                 $this->handleLegacyQuantity($part);
                 break;
             default:
-                throw new Exception("Unknown date format: $part");
+                throw new \Exception("Unknown date format: $part");
         }
     }
 
     public function julianToDate($part)
     {
-        if (strlen($part) != 5)
-            throw new Exception("First part is a julian date, but is not 5 characters long");
+        if (5 != \strlen($part)) {
+            throw new \Exception('First part is a julian date, but is not 5 characters long');
+        }
 
         // get the first 2 characters from $part for the year, rest is days
-        $year = "20" . substr($part, 0, 2);
+        $year = '20'.substr($part, 0, 2);
         $julian_date = substr($part, 2) - 1;
 
         // use the year and the number of days to calculate date
-        return date("Y-m-d", strtotime("$year-01-01 +$julian_date days"));
+        return date('Y-m-d', strtotime("$year-01-01 +$julian_date days"));
     }
 
-    private function handleLegacyQuantity($part){
+    private function handleLegacyQuantity($part)
+    {
         // $$9 is identifier, 5 digits for quantity always follows.
         // After quantity is [2-7] date identifier
         // If nothing follows quantity, then expiry date is null
         // If 1 or 0 next to quantity, then MMYY follows quantity with rest is lot
-        if(preg_match('/^\$\$9[0-9]{5}[2-7]{1}\d+/', $part)){
+        if (preg_match('/^\$\$9[0-9]{5}[2-7]{1}\d+/', $part)) {
             $this->handleLegacyPentaQuantityWithData($part);
-        } elseif(preg_match('/^\$\$9[0-9]{5}[^2-7]\d+/', $part)){
+        } elseif (preg_match('/^\$\$9[0-9]{5}[^2-7]\d+/', $part)) {
             $this->decoder->quantity = ltrim(substr($part, 3, 5), '0');
             $mm = substr($part, 8, 2);
             $yy = substr($part, 10, 2);
-            $max_day = date('t', strtotime($mm . '-' . $yy));
+            $max_day = date('t', strtotime($mm.'-'.$yy));
             $this->decoder->expiry_date = "20$yy-$mm-$max_day";
             $this->decoder->lot = substr($part, 12);
-        } elseif(preg_match('/^\$\$9[0-9]{5}[^\d]/', $part)){
+        } elseif (preg_match('/^\$\$9[0-9]{5}[^\d]/', $part)) {
             $this->decoder->quantity = ltrim(substr($part, 3, 5), '0');
-        } elseif(preg_match('/^\$\$8[0-9]{2}[2-7]{1}\d+/', $part)){
+        } elseif (preg_match('/^\$\$8[0-9]{2}[2-7]{1}\d+/', $part)) {
             $this->handleLegacyDoubleQuantityFormat($part);
-        } elseif(preg_match('/^\$\$8[0-9]{2}[^2-7]\d+/', $part)){
+        } elseif (preg_match('/^\$\$8[0-9]{2}[^2-7]\d+/', $part)) {
             $this->decoder->quantity = ltrim(substr($part, 3, 2), '0');
             $mm = substr($part, 5, 2);
             $yy = substr($part, 7, 2);
-            $max_day = date('t', strtotime($mm . '-' . $yy));
+            $max_day = date('t', strtotime($mm.'-'.$yy));
             $this->decoder->expiry_date = "20$yy-$mm-$max_day";
             $this->decoder->lot = substr($part, 9);
         }
     }
-    
-    private function handleLegacyDoubleQuantityFormat($part){
+
+    private function handleLegacyDoubleQuantityFormat($part)
+    {
         // first 2 characters after $$8 is quantity
         // next character is date identifier
         // if identifier is 2, after quantity comes expiration date in MMDDYY format and rest is lot
@@ -200,13 +185,13 @@ class HIBCSecondaryDataDecoder
         $identifier = substr($part, 5, 1);
         $this->decoder->quantity = ltrim(substr($part, 3, 2), '0');
         $date_field = substr($part, 6);
-        switch($identifier){
+        switch ($identifier) {
             case 2:
                 $mm = substr($date_field, 0, 2);
                 $dd = substr($date_field, 2, 2);
                 $yy = substr($date_field, 4, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd";
-                if(strlen($date_field) > 6){
+                if (\strlen($date_field) > 6) {
                     $this->decoder->lot = substr($date_field, 6);
                 }
                 break;
@@ -215,7 +200,7 @@ class HIBCSecondaryDataDecoder
                 $mm = substr($date_field, 2, 2);
                 $dd = substr($date_field, 4, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd";
-                if(strlen($date_field) > 6){
+                if (\strlen($date_field) > 6) {
                     $this->decoder->lot = substr($date_field, 6);
                 }
                 break;
@@ -225,13 +210,13 @@ class HIBCSecondaryDataDecoder
                 $dd = substr($date_field, 4, 2);
                 $hh = substr($date_field, 6, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd $hh";
-                if(strlen($date_field) > 8){
+                if (\strlen($date_field) > 8) {
                     $this->decoder->lot = substr($date_field, 8);
                 }
                 break;
             case 5:
                 $this->decoder->expiry_date = $this->julianToDate(substr($date_field, 0, 5));
-                if(strlen($date_field) > 5){
+                if (\strlen($date_field) > 5) {
                     $this->decoder->lot = substr($date_field, 5);
                 }
                 break;
@@ -239,7 +224,7 @@ class HIBCSecondaryDataDecoder
                 $expiry_date = $this->julianToDate(substr($date_field, 0, 5));
                 $hh = substr($date_field, 5, 2);
                 $this->decoder->expiry_date = date('Y-m-d H:i:s', strtotime("$expiry_date +$hh hours"));
-                if(strlen($date_field) > 7){
+                if (\strlen($date_field) > 7) {
                     $this->decoder->lot = substr($date_field, 7);
                 }
                 break;
@@ -247,12 +232,12 @@ class HIBCSecondaryDataDecoder
                 $this->decoder->lot = $date_field;
                 break;
             default:
-                throw new Exception("Unknown identifier for legacy secondary quantity data. Identifier: $identifier");                
+                throw new \Exception("Unknown identifier for legacy secondary quantity data. Identifier: $identifier");
         }
-
     }
 
-    private function handleLegacyPentaQuantityWithData($part){
+    private function handleLegacyPentaQuantityWithData($part)
+    {
         // first 5 characters after $$9 is quantity
         // next character after quantity is date identifier
         // if identifier is 2, after quantity comes expiration date in MMDDYY and rest is lot
@@ -264,13 +249,13 @@ class HIBCSecondaryDataDecoder
         $identifier = substr($part, 8, 1);
         $this->decoder->quantity = ltrim(substr($part, 3, 5), '0');
         $date_field = substr($part, 9);
-        switch($identifier){
+        switch ($identifier) {
             case '2':
                 $mm = substr($date_field, 0, 2);
                 $dd = substr($date_field, 2, 2);
                 $yy = substr($date_field, 4, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd";
-                if(strlen($date_field) > 6){
+                if (\strlen($date_field) > 6) {
                     $this->decoder->lot = substr($date_field, 6);
                 }
                 break;
@@ -279,7 +264,7 @@ class HIBCSecondaryDataDecoder
                 $mm = substr($date_field, 2, 2);
                 $dd = substr($date_field, 4, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd";
-                if(strlen($date_field) > 6){
+                if (\strlen($date_field) > 6) {
                     $this->decoder->lot = substr($date_field, 6);
                 }
                 break;
@@ -289,13 +274,13 @@ class HIBCSecondaryDataDecoder
                 $dd = substr($date_field, 4, 2);
                 $hh = substr($date_field, 6, 2);
                 $this->decoder->expiry_date = "20$yy-$mm-$dd $hh:00:00";
-                if(strlen($date_field) > 8){
+                if (\strlen($date_field) > 8) {
                     $this->decoder->lot = substr($date_field, 8);
                 }
                 break;
             case '5':
                 $this->decoder->expiry_date = $this->julianToDate($date_field);
-                if(strlen($date_field) > 5){
+                if (\strlen($date_field) > 5) {
                     $this->decoder->lot = substr($date_field, 5);
                 }
                 break;
@@ -303,7 +288,7 @@ class HIBCSecondaryDataDecoder
                 $expiry_date = $this->julianToDate($date_field);
                 $hh = substr($date_field, 5, 2);
                 $this->decoder->expiry_date = date('Y-m-d H:i:s', strtotime("$expiry_date +$hh hours"));
-                if(strlen($date_field) > 7){
+                if (\strlen($date_field) > 7) {
                     $this->decoder->lot = substr($date_field, 7);
                 }
                 break;
@@ -311,7 +296,7 @@ class HIBCSecondaryDataDecoder
                 $this->decoder->lot = $date_field;
                 break;
             default:
-                throw new Exception("Unknown identifier for legacy secondary quantity data. Identifier: $identifier");
-            }
+                throw new \Exception("Unknown identifier for legacy secondary quantity data. Identifier: $identifier");
+        }
     }
 }

--- a/src/ModuloCheckArray.php
+++ b/src/ModuloCheckArray.php
@@ -45,4 +45,3 @@ $modulo_check_characters = [
     '+' => 41,
     '%' => 42,
 ];
-    

--- a/tests/GS1Test.php
+++ b/tests/GS1Test.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Brixion\Bardecoder\Test;
 
-use PHPUnit\Framework\TestCase;
 use Brixion\Bardecoder\UdiDecoder;
+use PHPUnit\Framework\TestCase;
 
 final class GS1Test extends TestCase
 {
@@ -13,90 +13,86 @@ final class GS1Test extends TestCase
     // Because <gs> is the character that signifies an end of a part.
     private array $gs1 = [
         [
-            "gs1" => "010403507700171717240117108317326",
-            "product_code" => "403507700171",
-            "expiry_date" => "2024-01-17",
-            "lot" => "8317326",
+            'gs1' => '010403507700171717240117108317326',
+            'product_code' => '403507700171',
+            'expiry_date' => '2024-01-17',
+            'lot' => '8317326',
         ],
         [
-            "gs1" => "010019506205432717260806108356271<gs>",
-            "product_code" => "19506205432",
-            "expiry_date" => "2026-08-06",
-            "lot" => "8356271"
+            'gs1' => '010019506205432717260806108356271<gs>',
+            'product_code' => '19506205432',
+            'expiry_date' => '2026-08-06',
+            'lot' => '8356271',
         ],
         [
-            "gs1" => "01007073874690851724072210202407JV<gs>",
-            "product_code" => "70738746908",
-            "expiry_date" => "2024-07-22",
-            "lot" => "202407JV"
+            'gs1' => '01007073874690851724072210202407JV<gs>',
+            'product_code' => '70738746908',
+            'expiry_date' => '2024-07-22',
+            'lot' => '202407JV',
         ],
         [
-            "gs1" => "(01)0081705102232(11)121120210A63098<gs>",
-            "product_code" => "81705102232",
-            "expiry_date" => "2012-12-20",
-            "expiry_date" => null,
-            "lot" => "A63098"
+            'gs1' => '(01)0081705102232(11)121120210A63098<gs>',
+            'product_code' => '81705102232',
+            'expiry_date' => '2012-12-20',
+            'expiry_date' => null,
+            'lot' => 'A63098',
         ],
         [
-            "gs1" => "(01)00841396198953108117117<gs>(17)230301",
-            "product_code" => "84139619895",
-            "expiry_date" => "2023-03-01",
-            "lot" => "8117117",
+            'gs1' => '(01)00841396198953108117117<gs>(17)230301',
+            'product_code' => '84139619895',
+            'expiry_date' => '2023-03-01',
+            'lot' => '8117117',
         ],
         [
-            "gs1" => "(01)17310230007657(10)2136009<gs>(17)200926",
-            "product_code" => "1731023000765",
-            "expiry_date" => "2020-09-26",
-            "lot" => "2136009",
+            'gs1' => '(01)17310230007657(10)2136009<gs>(17)200926',
+            'product_code' => '1731023000765',
+            'expiry_date' => '2020-09-26',
+            'lot' => '2136009',
         ],
         [
-            "gs1" => "010406223417459510K010034<gs>112203151725022324066008292",
-            "product_code" => "66008292",
-            "expiry_date" => "2025-02-23",
-            "date_of_manufacture" => "2022-03-15",
-            "lot" => "K010034"
+            'gs1' => '010406223417459510K010034<gs>112203151725022324066008292',
+            'product_code' => '66008292',
+            'expiry_date' => '2025-02-23',
+            'date_of_manufacture' => '2022-03-15',
+            'lot' => 'K010034',
         ],
         [
-            "gs1" => "010571351300053910175146<gs>110000001700000021000<gs>301<gs>901906",
-            "lot" => "175146",
-            "product_code" => "571351300053",
-            "expiry_date" => ""
-        ]
-
+            'gs1' => '010571351300053910175146<gs>110000001700000021000<gs>301<gs>901906',
+            'lot' => '175146',
+            'product_code' => '571351300053',
+            'expiry_date' => '',
+        ],
     ];
 
-
-
-    /** @test */
-    public function it_can_instantiate_gs1(): void
+    public function testItCanInstantiateGs1(): void
     {
         foreach ($this->gs1 as $gs1) {
-            $decoder = new UdiDecoder($gs1["gs1"]);
+            $decoder = new UdiDecoder($gs1['gs1']);
             $this->assertInstanceOf(UdiDecoder::class, $decoder);
         }
     }
-    /** @test */
-    public function it_returns_gtin_from_gs1(): void
+
+    public function testItReturnsGtinFromGs1(): void
     {
         foreach ($this->gs1 as $gs1) {
-            $decoder = new UdiDecoder($gs1["gs1"]);
-            $this->assertEquals($gs1["product_code"], $decoder->product_code);
+            $decoder = new UdiDecoder($gs1['gs1']);
+            $this->assertEquals($gs1['product_code'], $decoder->product_code);
         }
     }
-    /** @test */
-    public function it_returns_expiry_date_from_gs1(): void
+
+    public function testItReturnsExpiryDateFromGs1(): void
     {
         foreach ($this->gs1 as $gs1) {
-            $decoder = new UdiDecoder($gs1["gs1"]);
-            $this->assertEquals($gs1["expiry_date"], $decoder->expiry_date);
+            $decoder = new UdiDecoder($gs1['gs1']);
+            $this->assertEquals($gs1['expiry_date'], $decoder->expiry_date);
         }
     }
-    /** @test */
-    public function it_returns_lot_from_gs1(): void
+
+    public function testItReturnsLotFromGs1(): void
     {
         foreach ($this->gs1 as $gs1) {
-            $decoder = new UdiDecoder($gs1["gs1"]);
-            $this->assertEquals($gs1["lot"], $decoder->lot);
+            $decoder = new UdiDecoder($gs1['gs1']);
+            $this->assertEquals($gs1['lot'], $decoder->lot);
         }
     }
 }

--- a/tests/HbicLicPrimaryDataStructureTest.php
+++ b/tests/HbicLicPrimaryDataStructureTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Brixion\Bardecoder\Test;
 
-use PHPUnit\Framework\TestCase;
 use Brixion\Bardecoder\UdiDecoder;
-use phpDocumentor\Reflection\Types\Void_;
+use PHPUnit\Framework\TestCase;
 
 final class HbicLicPrimaryDataStructureTest extends TestCase
 {
@@ -31,13 +30,13 @@ final class HbicLicPrimaryDataStructureTest extends TestCase
             'product_code' => '3152EU',
             'packaging_index' => '1',
             'check_character' => 'G',
-        ]
+        ],
     ];
 
-    /** @test
-     * UdiDecoder can extract lic from hibc
+    /**
+     * UdiDecoder can extract lic from hibc.
      */
-    public function it_extracts_lic_from_hibc(): void
+    public function testItExtractsLicFromHibc(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode']);
@@ -48,10 +47,10 @@ final class HbicLicPrimaryDataStructureTest extends TestCase
         }
     }
 
-    /** @test 
-     * Udidecoder can handle barcodes with leading and trailing *
+    /**
+     * Udidecoder can handle barcodes with leading and trailing *.
      */
-    public function it_extracts_lic_with_leading_and_trailing_asterisks_barcode(): void
+    public function testItExtractsLicWithLeadingAndTrailingAsterisksBarcode(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode_asterisk']);
@@ -62,11 +61,12 @@ final class HbicLicPrimaryDataStructureTest extends TestCase
         }
     }
 
-    /** @test
-     * UdiDecoder can extract product code from hibc
+    /**
+     * UdiDecoder can extract product code from hibc.
+     *
      * @throws \Exception
      */
-    public function it_extracts_product_code_from_hibc(): void
+    public function testItExtractsProductCodeFromHibc(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode']);
@@ -77,11 +77,12 @@ final class HbicLicPrimaryDataStructureTest extends TestCase
         }
     }
 
-    /** @test
-     * UdiDecoder can extract check character from hibc
+    /**
+     * UdiDecoder can extract check character from hibc.
+     *
      * @throws \Exception
      */
-    public function it_extracts_check_character_from_hibc(): void
+    public function testItExtractsCheckCharacterFromHibc(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode']);
@@ -92,29 +93,27 @@ final class HbicLicPrimaryDataStructureTest extends TestCase
         }
     }
 
-    /** @test
-     * UdiDecoder can check if hibc is valid
+    /**
+     * UdiDecoder can check if hibc is valid.
      */
-    public function it_checks_if_hibc_is_valid(): void
+    public function testItChecksIfHibcIsValid(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode']);
-            $this->assertEquals(
-                true,
+            $this->assertTrue(
                 $decoder->is_valid
             );
         }
     }
 
-    /** @test
-     * UdiDecoder can check if hibc is invalid
+    /**
+     * UdiDecoder can check if hibc is invalid.
      */
-    public function it_checks_if_hibc_is_invalid(): void
+    public function testItChecksIfHibcIsInvalid(): void
     {
         foreach ($this->hbics as $hbic) {
             $decoder = new UdiDecoder($hbic['barcode_invalid']);
-            $this->assertEquals(
-                false,
+            $this->assertFalse(
                 $decoder->is_valid
             );
         }

--- a/tests/HbicLicSecondaryDataStructureTest.php
+++ b/tests/HbicLicSecondaryDataStructureTest.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Brixion\Bardecoder\Test;
 
-use PHPUnit\Framework\TestCase;
 use Brixion\Bardecoder\UdiDecoder;
-use phpDocumentor\Reflection\Types\Void_;
+use PHPUnit\Framework\TestCase;
 
 final class HbicLicSecondaryDataStructureTest extends TestCase
 {
@@ -17,40 +16,38 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
     // I am not using a DataProvider here to allow usage of array keys
     private array $hibcs = [
         [
-            "barcode" => "+E241BW9020/$$8013230806200804L",
-            "product_code" => "BW902",
-            "check_character" => "L",
-            "lic" => "E241",
-            "secondary_data" => "$$8013230806200804",
-            "packaging_index" => "0",
-            "expiry_date" => "2023-08-06",
-            "lot" => "200804",
-            "quantity" => "1"
-            
+            'barcode' => '+E241BW9020/$$8013230806200804L',
+            'product_code' => 'BW902',
+            'check_character' => 'L',
+            'lic' => 'E241',
+            'secondary_data' => '$$8013230806200804',
+            'packaging_index' => '0',
+            'expiry_date' => '2023-08-06',
+            'lot' => '200804',
+            'quantity' => '1',
         ],
         [
-            "barcode" => "+E490HE21KL1/$+HEK13044/16D20220531/Q1$",
-            "lic" => "E490",
-            "product_code" => "HE21KL",
-            "secondary_data" => "$+HEK13044/16D20220531/Q1",
-            "packaging_index" => "1",
-            "check_character" => "$",
-            "link_character" => "L",
-            "lot" => "HEK13044",
-            "date_of_manufacture" => "2022-05-31",
-            "quantity" => "1",
-
+            'barcode' => '+E490HE21KL1/$+HEK13044/16D20220531/Q1$',
+            'lic' => 'E490',
+            'product_code' => 'HE21KL',
+            'secondary_data' => '$+HEK13044/16D20220531/Q1',
+            'packaging_index' => '1',
+            'check_character' => '$',
+            'link_character' => 'L',
+            'lot' => 'HEK13044',
+            'date_of_manufacture' => '2022-05-31',
+            'quantity' => '1',
         ],
         [
-            "barcode" => "+DVIV627261AN1/$$3250303Z025XHKW",
-            "lic" => "DVIV",
-            "secondary_data" => "$$3250303Z025XHK",
-            "check_character" => "W",
-            "link_character" => "K",
-            "packaging_index" => "1",
-            "product_code" => "627261AN",
-            "lot" => "Z025XHK",
-            "expiry_date" => "2025-03-03"
+            'barcode' => '+DVIV627261AN1/$$3250303Z025XHKW',
+            'lic' => 'DVIV',
+            'secondary_data' => '$$3250303Z025XHK',
+            'check_character' => 'W',
+            'link_character' => 'K',
+            'packaging_index' => '1',
+            'product_code' => '627261AN',
+            'lot' => 'Z025XHK',
+            'expiry_date' => '2025-03-03',
         ],
         // 1
         [
@@ -220,7 +217,7 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             'packaging_index' => '1',
             'check_character' => 'R',
             'link_character' => '2',
-            'secondary_data' =>  '$$3231231BC34567/S4012',
+            'secondary_data' => '$$3231231BC34567/S4012',
 
             'secondary_data_flag' => '$$3',
             'expiry_date' => '2023-12-31',
@@ -249,7 +246,7 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             'link_character' => '3',
             'secondary_data' => '$$32601270000276973',
             'lot' => '0000276973',
-            'expiry_date' => '2026-01-27'
+            'expiry_date' => '2026-01-27',
         ],
         // legacy quantity barcode
         [
@@ -261,9 +258,9 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             'link_character' => '1',
             'secondary_data' => '$$90000112232100721',
             'lot' => '2100721',
-            'expiry_date' => '2023-12-31'
+            'expiry_date' => '2023-12-31',
         ],
-        [ 
+        [
             'barcode' => '+E235817C19/$$9000067101822%',
             'lic' => 'E235',
             'product_code' => '817C1',
@@ -274,7 +271,7 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             'lot' => '101822',
             'expiry_date' => null,
         ],
-        [ 
+        [
             'barcode' => '+E1652101109/$$9000063260831L01656I',
             'lic' => 'E165',
             'product_code' => '210110',
@@ -306,87 +303,74 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             'secondary_data' => '$$9000012103124181561',
             'lot' => '181561',
             'expiry_date' => '2024-10-31',
-        ]
+        ],
     ];
 
-        
-    /** @test
-     * 
-     */
-    public function it_extracts_lic_test(): void
+    public function testItExtractsLicTest(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['lic'])) {
                 $this->assertEquals($hibc['lic'], $decoder->lic);
             } else {
-                $this->assertEquals(null, $decoder->lic);
+                $this->assertNull($decoder->lic);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_product_code_test(): void
+    public function testItExtractsProductCodeTest(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['product_code'])) {
                 $this->assertEquals($hibc['product_code'], $decoder->product_code);
             } else {
-                $this->assertEquals(null, $decoder->product_code);
+                $this->assertNull($decoder->product_code);
             }
         }
     }
 
-    /** @test
-     * Disabled because it is not needed at this time
+    /**
+     * Disabled because it is not needed at this time.
      */
-    public function it_extracts_packaging_index_test(): void
+    public function testItExtractsPackagingIndexTest(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['packaging_index'])) {
                 $this->assertEquals($hibc['packaging_index'], $decoder->packaging_index);
             } else {
-                $this->assertEquals(null, $decoder->packaging_index);
+                $this->assertNull($decoder->packaging_index);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_check_character_test(): void
+    public function testItExtractsCheckCharacterTest(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['check_character'])) {
                 $this->assertEquals($hibc['check_character'], $decoder->check_character);
             } else {
-                $this->assertEquals(null, $decoder->check_character);
+                $this->assertNull($decoder->check_character);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_secondary_data_test(): void
+    public function testItExtractsSecondaryDataTest(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['secondary_data'])) {
                 $this->assertEquals($hibc['secondary_data'], $decoder->secondary_data);
             } else {
-                $this->assertEquals(null, $decoder->secondary_data);
+                $this->assertNull($decoder->secondary_data);
             }
         }
     }
 
-    /** test
-     * 
+    /** test.
+     *
      */
     public function is_valid_test(): void
     {
@@ -397,7 +381,7 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
     }
 
     /** test
-     * Disabled because it is not needed at this time
+     * Disabled because it is not needed at this time.
      */
     public function is_invalid_test(): void
     {
@@ -406,73 +390,61 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             if (isset($hibc['barcode_invalid'])) {
                 $this->assertEquals($hibc['barcode_invalid'], $decoder->barcode_invalid);
             } else {
-                $this->assertEquals(null, $decoder->barcode_invalid);
+                $this->assertNull($decoder->barcode_invalid);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_lot(): void
+    public function testItExtractsLot(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['lot'])) {
                 $this->assertEquals($hibc['lot'], $decoder->lot);
             } else {
-                $this->assertEquals(null, $decoder->lot);
+                $this->assertNull($decoder->lot);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_expiry_date(): void
+    public function testItExtractsExpiryDate(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['expiry_date'])) {
                 $this->assertEquals($hibc['expiry_date'], $decoder->expiry_date);
             } else {
-                $this->assertEquals(null, $decoder->expiry_date);
+                $this->assertNull($decoder->expiry_date);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_date_of_manufacture(): void
+    public function testItExtractsDateOfManufacture(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['date_of_manufacture'])) {
                 $this->assertEquals($hibc['date_of_manufacture'], $decoder->date_of_manufacture);
             } else {
-                $this->assertEquals(null, $decoder->date_of_manufacture);
+                $this->assertNull($decoder->date_of_manufacture);
             }
         }
     }
 
-    /** @test
-     * 
-     */
-    public function it_extracts_serial_number(): void
+    public function testItExtractsSerialNumber(): void
     {
         foreach ($this->hibcs as $hibc) {
             $decoder = new UdiDecoder($hibc['barcode']);
             if (isset($hibc['serial_number'])) {
                 $this->assertEquals($hibc['serial_number'], $decoder->serial_number);
             } else {
-                $this->assertEquals(null, $decoder->serial_number);
+                $this->assertNull($decoder->serial_number);
             }
         }
     }
 
     /** test
-     * Disabled because it is not needed at this time
+     * Disabled because it is not needed at this time.
      */
     public function it_extracts_quantity_identifier(): void
     {
@@ -481,13 +453,13 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             if (isset($hibc['quantity_identifier'])) {
                 $this->assertEquals($hibc['quantity_identifier'], $decoder->quantity_identifier);
             } else {
-                $this->assertEquals(null, $decoder->quantity_identifier);
+                $this->assertNull($decoder->quantity_identifier);
             }
         }
     }
 
     /** test
-     * Disabled because it is not needed at this time
+     * Disabled because it is not needed at this time.
      */
     public function it_extracts_quantity(): void
     {
@@ -496,13 +468,13 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             if (isset($hibc['quantity'])) {
                 $this->assertEquals($hibc['quantity'], $decoder->quantity);
             } else {
-                $this->assertEquals(null, $decoder->quantity);
+                $this->assertNull($decoder->quantity);
             }
         }
     }
 
-    /** test
-     * 
+    /** test.
+     *
      */
     public function it_extracts_link_character(): void
     {
@@ -511,7 +483,7 @@ final class HbicLicSecondaryDataStructureTest extends TestCase
             if (isset($hibc['link_character'])) {
                 $this->assertEquals($hibc['link_character'], $decoder->link_character);
             } else {
-                $this->assertEquals(null, $decoder->link_character);
+                $this->assertNull($decoder->link_character);
             }
         }
     }


### PR DESCRIPTION
## 🔍 Summary 

This PR adds PHP CS Fixer as a development dependency and applies the `@Symfony` coding standard to the entire codebase, modernizing code style and improving consistency.

## 📝 Description

* Added friendsofphp/php-cs-fixer ^3.88 as dev dependency with `@Symfony` and `@Symfony:risky` rulesets
* Created `.php-cs-fixer.dist.php` with finder excluding vendor/var directories and risky rules enabled